### PR TITLE
js file extension check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ client.cooldowns = new Collection<string, number>()
 
 const handlersDir = join(__dirname, "./handlers")
 readdirSync(handlersDir).forEach(handler => {
+    if (!handler.endsWith(".js")) return;
     require(`${handlersDir}/${handler}`)(client)
 })
 


### PR DESCRIPTION
If you create source map files this method loads *.js.map files too. To avoid this we should only allow *.js files.