### PR TITLE
Fix for Case Sensitivity in Prefix Command Names

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -18,10 +18,10 @@ const event: BotEvent = {
         if (message.channel.type !== ChannelType.GuildText) return;
 
         let args = message.content.substring(prefix.length).split(" ")
-        let command = message.client.commands.get(args[0])
+        let command = message.client.commands.get(args[0].toLowerCase())
 
         if (!command) {
-            let commandFromAlias = message.client.commands.find((command) => command.aliases.includes(args[0]))
+            let commandFromAlias = message.client.commands.find((command) => command.aliases.includes(args[0].toLowerCase()))
             if (commandFromAlias) command = commandFromAlias
             else return;
         }

--- a/src/handlers/Command.ts
+++ b/src/handlers/Command.ts
@@ -23,7 +23,7 @@ module.exports = (client : Client) => {
         if (!file.endsWith(".js")) return;
         let command : Command = require(`${commandsDir}/${file}`).default
         commands.push(command)
-        client.commands.set(command.name, command)
+        client.commands.set(command.name.toLowerCase(), command)
     })
 
     const rest = new REST({version: "10"}).setToken(process.env.TOKEN);


### PR DESCRIPTION
It addresses a potential issue with the use of capital letters in prefix command names, thus ensuring that if a user inputs the command with unexpected capitalization, it does not return an error. This is achieved through the use of the toLowerCase function in both the event and handler.

```js
/* events > messageCreate */
let command = message.client.commands.get(args[0].toLowerCase());
command.aliases.includes(args[0].toLowerCase())
/* handlers > Command */
client.commands.set(command.name.toLowerCase(), command)
```